### PR TITLE
【Fixed】チームリーダーが、他のチームメンバーにリーダー権限を渡せる機能を実装すること issues/#65

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -31,7 +31,9 @@ class TeamsController < ApplicationController
   end
 
   def update
+    before_owner_id = @team.owner_id
     if @team.update(team_params)
+      TransferMailer.transfer_mail(@team).deliver unless @team.owner_id == before_owner_id
       redirect_to @team, notice: I18n.t('views.messages.update_team')
     else
       flash.now[:error] = I18n.t('views.messages.failed_to_save_team')

--- a/app/mailers/transfer_mailer.rb
+++ b/app/mailers/transfer_mailer.rb
@@ -1,0 +1,6 @@
+class TransferMailer < ApplicationMailer
+  def transfer_mail(team)
+    @team = team
+    mail to: @team.owner.email, subject: "TRANSFER OF OWNERSHIP"
+  end
+end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -44,6 +44,11 @@
                       <% if current_user.id == @team.owner.id || current_user.id == assign.user.id %>
                         <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
                       <% end %>
+                      <% if current_user.id == @team.owner.id && current_user.id != assign.user.id%>
+                        <%= form_with(model: @team, local: true) do |form| %>
+                          <td><%= form.hidden_field :owner_id, value: assign.user_id %><%= form.submit '権限移動', class: 'btn btn-warning' %></td>
+                        <% end %>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/transfer_mailer/transfer_mail.html.erb
+++ b/app/views/transfer_mailer/transfer_mail.html.erb
@@ -1,0 +1,3 @@
+<h1>TRANSFER OF OWNERSHIP</h1>
+<p>TEAM: <%= @team.name %></p>
+<p>NEW OWNER: <%= @team.owner.email %></p>

--- a/app/views/transfer_mailer/transfer_mail.html.erb
+++ b/app/views/transfer_mailer/transfer_mail.html.erb
@@ -1,3 +1,2 @@
-<h1>TRANSFER OF OWNERSHIP</h1>
+<h1>YOU ARE THE OWNER</h1>
 <p>TEAM: <%= @team.name %></p>
-<p>NEW OWNER: <%= @team.owner.email %></p>

--- a/spec/mailers/previews/transfer_mailer_preview.rb
+++ b/spec/mailers/previews/transfer_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/transfer_mailer
+class TransferMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/transfer_mailer_spec.rb
+++ b/spec/mailers/transfer_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe TransferMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
以下の要件を実装

- [ ] 権限移動のボタンを押すとTeamのオーナーが選択したUserに変更されるよう実装
- [ ] Teamのオーナーが変更されたら新しくオーナーになったUserに通知メールが飛ぶよう実装
