### PR TITLE
【Fixed】アジェンダの削除機能を実装すること issues/#67

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -24,6 +24,7 @@ class AgendasController < ApplicationController
 
   def destroy
     @agenda.destroy
+    DeleteMailer.delete_mail(@agenda).deliver
     redirect_to dashboard_url, notice: 'Delete Agenda'
   end
 

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,10 +15,15 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
     end
+  end
+
+  def destroy
+    @agenda.destroy
+    redirect_to dashboard_url, notice: 'Delete Agenda'
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,6 @@
 class AgendasController < ApplicationController
   before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :only_agendaowners, only: %i[destroy]
 
   def index
     @agendas = Agenda.all
@@ -34,5 +35,11 @@ class AgendasController < ApplicationController
 
   def agenda_params
     params.fetch(:agenda, {}).permit %i[title description]
+  end
+
+  def only_agendaowners
+    unless current_user.id == @agenda.user_id || current_user.id == @agenda.team.owner.id
+      redirect_to dashboard_url, notice: 'Permission denied'
+    end
   end
 end

--- a/app/mailers/delete_mailer.rb
+++ b/app/mailers/delete_mailer.rb
@@ -1,0 +1,10 @@
+class DeleteMailer < ApplicationMailer
+  def delete_mail(agenda)
+    @agenda = agenda
+    @emails = []
+    @agenda.team.members.each do |member|
+      @emails.push(member.email)
+    end
+    mail to: @emails, subject: 'DELETE AGENDA'
+  end
+end

--- a/app/views/delete_mailer/delete_mail.html.erb
+++ b/app/views/delete_mailer/delete_mail.html.erb
@@ -1,0 +1,2 @@
+<h1>AGENDA DELETED</h1>
+<p>AGENDA: <%= @agenda.title %></p>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,13 +30,14 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
+            <div class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
               </p>
-            </a>
+                <%= link_to I18n.t('views.button.delete'), agenda_path(agenda), method: :delete, class: 'ml-4' %>
+            </div>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -3,6 +3,8 @@
   <%= link_to dashboard_url, class: 'brand-link' do %>
     <span class="brand-text font-weight-light">DIVE INTO POST</span>
   <% end %>
+  <%= current_user.current_sign_in_at if user_signed_in? %>
+  <%= link_to 'Logout', destroy_user_session_path, method: :delete %>
 
   <!-- Sidebar -->
   <div class="sidebar">

--- a/spec/mailers/delete_mailer_spec.rb
+++ b/spec/mailers/delete_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe DeleteMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/delete_mailer_preview.rb
+++ b/spec/mailers/previews/delete_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/delete_mailer
+class DeleteMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
以下の要件を実装

- [ ] AgendasControllerのdestroyアクションを追加し、そこに機能追加する
- [ ] Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
- [ ] Agendaに紐づいているarticleも一緒に削除される
- [ ] Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
- [ ] Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ